### PR TITLE
과제 채점 페이지에서 채점시 사이드바의 props를 다시 로드하도록 함

### DIFF
--- a/page/src/components/AssignmentBox.js
+++ b/page/src/components/AssignmentBox.js
@@ -1,10 +1,13 @@
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
+import {useAssignmentState} from '../shared/AssignmentState';
 
 import {Link} from 'react-router-dom';
 import { Grid, Paper } from '@material-ui/core';
 
 const AssignmentBox = (props)=>{
+  const asState = useAssignmentState();
+
   const {type, as_info} = props;
   const state = as_info.assignmentState;
   const date = new Date(as_info.deadline);
@@ -19,16 +22,17 @@ const AssignmentBox = (props)=>{
 
   if(type===0){
     switch(state){
-      case 0: state_word="공개 전"; color = "rgb(56, 142, 60)"; break;
-      case 1: state_word="진행 중"; color = "#f50057"; break;
-      case 2: state_word="마감 됨"; color = "black"; break;
+      case asState["notReleased"]: state_word="공개 전"; color = "rgb(56, 142, 60)"; break;
+      case asState["released"]: state_word="진행 중"; color = "#f50057"; break;
+      case asState["scoring"]: state_word="마감 됨"; color = "#3f51b5"; break;
+      case asState["done"]: state_word="채점 완료"; color = "black"; break;
     }
   }else if(type===1){
     switch(state){
-      case 0: state_word="공개 전"; color = "#f50057"; break;
-      case 1: state_word="제출 필요"; color = "rgb(56, 142, 60)"; break;
-      case 2: state_word="채점 중"; color = "#3f51b5"; break;
-      case 3: state_word="채점 완료"; color = "black"; break;
+      case asState["notReleased"]: state_word="공개 전"; color = "#f50057"; break;
+      case asState["released"]: state_word="제출 필요"; color = "rgb(56, 142, 60)"; break;
+      case asState["scoring"]: state_word="채점 중"; color = "#3f51b5"; break;
+      case asState["done"]: state_word="채점 완료"; color = "black"; break;
     }
   }
   const useStyles = makeStyles((theme) => ({

--- a/page/src/components/SideBar.js
+++ b/page/src/components/SideBar.js
@@ -23,24 +23,29 @@ const useStyles = makeStyles((theme) => ({
   }));
   
 const SideBar = (props) => {
-    const classes = useStyles();    
-    const {type, drawerClose, assignmentInfo} = props;
+    const classes = useStyles();
+    const {type, drawerClose} = props;
+    const [assignmentInfo, setAsInfo] = useState(props.assignmentInfo);
     const [update, forceUpdate] = useState(false); // rendering update용
     const [assignmentClass, setAsClass] = useState([[],[],[],[]]); 
 
     const asState = useAssignmentState();
     
     useEffect(()=>{
+        setAsInfo(props.assignmentInfo);
+    },[props.assignmentInfo]);
+
+    useEffect(() => {
         function preProcessingAssign(){
+            let newAsClass = [[],[],[],[]];
             assignmentInfo.map((as)=>{
-                let tmp = assignmentClass;
-                tmp[as[2]].push(as);
-                setAsClass(tmp);
-            })
+                newAsClass[as[2]].push(as);
+            });
+            setAsClass(newAsClass);
         };
 
         preProcessingAssign();
-    },[])
+    }, [assignmentInfo]);
 
     useEffect(()=>{
         forceUpdate(!update);

--- a/page/src/pages/Main.js
+++ b/page/src/pages/Main.js
@@ -89,6 +89,7 @@ function Main(props) {
   }, []);
 
   function setSideBarAssignment(){
+    console.log("entered");
     axios.get('/v1/assignment', { withCredentials: true })
       .then(res => {
         let assign = res.data;
@@ -175,7 +176,11 @@ function Main(props) {
                 }, "margin-top-64", "contents_side")}
             >
               <Route exact path="/home" component={Home} />
-              <Route exact path="/home/assignment/:asId" component={user.type === 1 ? Assignment : Scoring} />
+              <Route exact path="/home/assignment/:asId" 
+                render={user.type === 1 ? 
+                  ({match}) => <Assignment match={match}></Assignment> : 
+                  ({match}) => <Scoring match={match} onUpdate={setSideBarAssignment}></Scoring>} 
+              />
               <Route exact path="/home/setting" component={Setting} />
               <Route exact path="/home/setting/:asId" component={SetAssignment} />
               <Route exact path="/home/setList" component={SetStudentList} />

--- a/page/src/pages/Scoring.js
+++ b/page/src/pages/Scoring.js
@@ -174,6 +174,8 @@ const Scoring = (props) => {
                 newAnsDict[userNum].answers.find(ans => ans.questionId === quesId).score = score;
                 console.log(newAnsDict)
                 setAnswersDict(newAnsDict);
+                if (props.onUpdate)
+                    props.onUpdate();
             })
             .catch(err => {
                 const status = err?.response?.status;


### PR DESCRIPTION
* resolves: #108 

Sidebar와 Scoring은 모두 Main의 자식 컴포넌트이고, Main에서 과제 정보를 fetch하여 Sidebar의 props로 넘겨주는 방식이므로, Main에서 Scoring에 onUpdate 이벤트 핸들러를 제공하고, 채점이 될 때마다 Scoring에서 이를 호출하여 Sidebar의 과제 정보를 다시 fetch해 Sidebar에 반영하였습니다. 이렇게 하면 Scoring의 자동 저장을 그대로 유지하면서도 별도의 새로고침 없이 변경된 과제 정보를 반영할 수 있습니다.

![Peek 2020-09-16 03-10](https://user-images.githubusercontent.com/49356944/93249494-5c2c0800-f7cc-11ea-879c-07847e56abf5.gif)
